### PR TITLE
Menu rendering optimization

### DIFF
--- a/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
+++ b/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
@@ -7,6 +7,7 @@ import dev.tocraft.craftedcore.registration.KeyBindingRegistry;
 import dev.tocraft.remorphed.handler.client.ClientPlayerRespawnHandler;
 import dev.tocraft.remorphed.mixin.client.accessor.GuiGraphicsAccessor;
 import dev.tocraft.remorphed.network.ClientNetworking;
+import dev.tocraft.remorphed.screen.RemorphedMenu;
 import dev.tocraft.remorphed.screen.render.GuiShapeRenderState;
 import dev.tocraft.remorphed.tick.KeyPressHandler;
 import net.fabricmc.api.EnvType;
@@ -36,6 +37,7 @@ public class RemorphedClient {
         ClientNetworking.registerPacketHandlers();
 
         ClientPlayerEvents.CLIENT_PLAYER_RESPAWN.register(new ClientPlayerRespawnHandler());
+        ClientPlayerEvents.CLIENT_PLAYER_QUIT.register(player -> RemorphedMenu.clearCache()); // clear cache on world quit
     }
 
     public static void renderEntityInInventory(

--- a/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
+++ b/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
@@ -49,12 +49,21 @@ public class RemorphedClient {
             Vector3f translation,
             Quaternionf rotation,
             @Nullable Quaternionf overrideCameraAngle,
-            LivingEntity entity
+            LivingEntity entity,
+            @Nullable EntityRenderState cachedRenderState
     ) {
-        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
-        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
-        EntityRenderState entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
-        entityRenderState.hitboxesRenderState = null;
+        EntityRenderState entityRenderState;
+        
+        if (cachedRenderState != null) {
+            // Use cached render state to avoid texture/model reloading
+            entityRenderState = cachedRenderState;
+        } else {
+            // Fallback: create new render state (shouldn't happen with proper caching)
+            EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
+            EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
+            entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
+            entityRenderState.hitboxesRenderState = null;
+        }
 
         GuiGraphicsAccessor accessor = ((GuiGraphicsAccessor) guiGraphics);
         accessor.getGuiRenderState().submitPicturesInPictureState(new GuiShapeRenderState(id, entityRenderState, translation, rotation, overrideCameraAngle, x1, y1, x2, y2, scale, accessor.getScissorStack().peek()));

--- a/common/src/main/java/dev/tocraft/remorphed/command/RemorphedCommand.java
+++ b/common/src/main/java/dev/tocraft/remorphed/command/RemorphedCommand.java
@@ -362,6 +362,7 @@ public class RemorphedCommand implements CommandEvents.CommandRegistration {
             rootNode.addChild(hasSkin);
         }
 
+
         dispatcher.getRoot().addChild(rootNode);
 
     }

--- a/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
@@ -21,12 +21,17 @@ import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
 import net.minecraft.client.gui.layouts.LinearLayout;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.monster.MagmaCube;
+import net.minecraft.world.entity.monster.Slime;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -47,6 +52,11 @@ public class RemorphedMenu extends Screen {
     private final List<GameProfile> unlockedSkins = new CopyOnWriteArrayList<>();
     private final Map<ShapeType<?>, Mob> renderEntities = new ConcurrentHashMap<>();
     private final Map<GameProfile, FakeClientPlayer> renderPlayers = new ConcurrentHashMap<>();
+    
+    // Cache for EntityRenderState with proper scale - this is what prevents visual reloading
+    private static final Map<ShapeType<?>, EntityRenderState> CACHED_ENTITY_RENDER_STATES = new ConcurrentHashMap<>();
+    private static final Map<GameProfile, EntityRenderState> CACHED_PLAYER_RENDER_STATES = new ConcurrentHashMap<>();
+    
 
     private final SearchWidget searchBar = createSearchBar();
     private final Button helpButton = createHelpButton();
@@ -198,6 +208,7 @@ public class RemorphedMenu extends Screen {
                         if (fakePlayer != null) {
                             boolean bl = Objects.equals(SkinShifter.getCurrentSkin(minecraft.player), skinProfile.getId()) && currentType == null;
                             if (bl) currentRow = i;
+                            EntityRenderState cachedPlayerRenderState = CACHED_PLAYER_RENDER_STATES.get(skinProfile);
                             row.add(new SkinWidget(
                                     0,
                                     0,
@@ -208,7 +219,8 @@ public class RemorphedMenu extends Screen {
                                     this,
                                     PlayerMorph.getFavoriteSkins(minecraft.player).contains(skinProfile),
                                     bl,
-                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.CONFIG.playerKillValue < 1 ? -1 : Remorphed.CONFIG.playerKillValue * PlayerMorph.getPlayerKills(minecraft.player, skinProfile.getId()) - PlayerMorph.getCounter(minecraft.player, skinProfile.getId())
+                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.CONFIG.playerKillValue < 1 ? -1 : Remorphed.CONFIG.playerKillValue * PlayerMorph.getPlayerKills(minecraft.player, skinProfile.getId()) - PlayerMorph.getCounter(minecraft.player, skinProfile.getId()),
+                                    cachedPlayerRenderState
                             ));
                         } else {
                             Remorphed.LOGGER.error("invalid skin profile: {}", skinProfile);
@@ -219,6 +231,7 @@ public class RemorphedMenu extends Screen {
                         if (entity != null) {
                             boolean bl = type.equals(currentType);
                             if (bl) currentRow = i;
+                            EntityRenderState cachedRenderState = CACHED_ENTITY_RENDER_STATES.get(type);
                             row.add(new EntityWidget<>(
                                     i * Remorphed.CONFIG.shapes_per_row + j,
                                     0,
@@ -230,7 +243,8 @@ public class RemorphedMenu extends Screen {
                                     this,
                                     PlayerMorph.getFavoriteShapes(minecraft.player).contains(type),
                                     bl,
-                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.getKillValue(type.getEntityType()) < 1 ? -1 : Remorphed.getKillValue(type.getEntityType()) * PlayerMorph.getKills(minecraft.player, type) - PlayerMorph.getCounter(minecraft.player, type)
+                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.getKillValue(type.getEntityType()) < 1 ? -1 : Remorphed.getKillValue(type.getEntityType()) * PlayerMorph.getKills(minecraft.player, type) - PlayerMorph.getCounter(minecraft.player, type),
+                                    cachedRenderState
                             ));
                         } else {
                             Remorphed.LOGGER.error("invalid shape type: {}", type.getEntityType().getDescriptionId());
@@ -252,13 +266,67 @@ public class RemorphedMenu extends Screen {
         unlockedShapes.clear();
         renderEntities.clear();
         List<ShapeType<?>> validUnlocked = Remorphed.getUnlockedShapes(player);
+        
+        
+        
+        // Create new entities and render states only for newly unlocked shapes
         for (ShapeType<?> type : validUnlocked) {
-            Entity entity = type.create(Minecraft.getInstance().level, player);
-            if (entity instanceof Mob living) {
-                unlockedShapes.add(type);
-                renderEntities.put(type, living);
+            if (!CACHED_ENTITY_RENDER_STATES.containsKey(type)) {
+                try {
+                    Entity entity = type.create(Minecraft.getInstance().level, player);
+                    if (entity instanceof Mob living) {
+                        // Fix slimes and magma cubes - set size to 1 (smallest)
+                        if (living instanceof Slime slime) {
+                            slime.setSize(1, true);
+                        } else if (living instanceof MagmaCube magmaCube) {
+                            magmaCube.setSize(1, true);
+                        }
+                        
+                        // Disable animations for consistent rendering
+                        living.setNoAi(true);
+                        living.setInvulnerable(true);
+                        
+                        // Create and cache the EntityRenderState with 1.0F scale (like original)
+                        // The actual scaling is handled by the widget's size calculation
+                        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
+                        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(living);
+                        EntityRenderState entityRenderState = entityRenderer.createRenderState(living, 1.0F);
+                        entityRenderState.hitboxesRenderState = null;
+                        CACHED_ENTITY_RENDER_STATES.put(type, entityRenderState);
+                        
+                        // Don't cache the entity - create fresh each time to avoid state issues
+                        renderEntities.put(type, living);
+                    }
+                } catch (Exception e) {
+                    Remorphed.LOGGER.warn("Failed to create entity for type {}: {}", type.getEntityType(), e.getMessage());
+                }
+            } else {
+                // Create fresh entity but use cached render state
+                Entity entity = type.create(Minecraft.getInstance().level, player);
+                if (entity instanceof Mob living) {
+                    // Fix slimes and magma cubes - set size to 1 (smallest)
+                    if (living instanceof Slime slime) {
+                        slime.setSize(1, true);
+                    } else if (living instanceof MagmaCube magmaCube) {
+                        magmaCube.setSize(1, true);
+                    }
+                    
+                    // Disable animations for consistent rendering
+                    living.setNoAi(true);
+                    living.setInvulnerable(true);
+                    
+                    renderEntities.put(type, living);
+                }
             }
         }
+        
+        // Add all valid unlocked shapes
+        for (ShapeType<?> type : validUnlocked) {
+            if (CACHED_ENTITY_RENDER_STATES.containsKey(type)) {
+                unlockedShapes.add(type);
+            }
+        }
+        
 
         Remorphed.LOGGER.info("Loaded {} entities for rendering", unlockedShapes.size());
     }
@@ -267,19 +335,63 @@ public class RemorphedMenu extends Screen {
         unlockedSkins.clear();
         renderPlayers.clear();
         List<GameProfile> validUnlocked = Remorphed.getUnlockedSkins(player);
-        for (GameProfile profile : validUnlocked) {
-            if (profile.getId() != player.getUUID()) {
-                FakeClientPlayer entity = null;
-                if (minecraft != null) {
-                    entity = new FakeClientPlayer(minecraft.level, profile);
+        
+        // Filter out the player's own skin
+        List<GameProfile> filteredUnlocked = validUnlocked.stream()
+            .filter(profile -> profile.getId() != player.getUUID())
+            .toList();
+        
+        // Create new fake players and render states only for newly unlocked skins
+        for (GameProfile profile : filteredUnlocked) {
+            if (!CACHED_PLAYER_RENDER_STATES.containsKey(profile)) {
+                try {
+                    if (minecraft != null) {
+                        FakeClientPlayer entity = new FakeClientPlayer(minecraft.level, profile);
+                        
+                        // Create and cache the EntityRenderState with 1.0F scale (like original)
+                        // The actual scaling is handled by the widget's size calculation
+                        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
+                        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
+                        EntityRenderState entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
+                        entityRenderState.hitboxesRenderState = null;
+                        CACHED_PLAYER_RENDER_STATES.put(profile, entityRenderState);
+                        
+                        // Don't cache the player - create fresh each time to avoid state issues
+                        renderPlayers.put(profile, entity);
+                    }
+                } catch (Exception e) {
+                    Remorphed.LOGGER.warn("Failed to create fake player for profile {}: {}", profile.getName(), e.getMessage());
                 }
-                unlockedSkins.add(profile);
-                renderPlayers.put(profile, entity);
+            } else {
+                // Create fresh player but use cached render state
+                if (minecraft != null) {
+                    FakeClientPlayer entity = new FakeClientPlayer(minecraft.level, profile);
+                    renderPlayers.put(profile, entity);
+                }
             }
         }
+        
+        // Add all valid unlocked skins
+        for (GameProfile profile : filteredUnlocked) {
+            if (CACHED_PLAYER_RENDER_STATES.containsKey(profile)) {
+                unlockedSkins.add(profile);
+            }
+        }
+        
 
         Remorphed.LOGGER.info("Loaded {} players for rendering", unlockedSkins.size());
     }
+    
+    /**
+     * Clears the entity and player caches. Call this when the player logs out
+     * or when you want to force a complete refresh of all entities.
+     */
+    public static void clearCache() {
+        CACHED_ENTITY_RENDER_STATES.clear();
+        CACHED_PLAYER_RENDER_STATES.clear();
+        Remorphed.LOGGER.info("Cleared render state caches");
+    }
+    
 
     protected void addFooter() {
         this.layout.addToFooter(Button.builder(CommonComponents.GUI_DONE, (button) -> this.onClose()).width(200).build());
@@ -343,3 +455,4 @@ public class RemorphedMenu extends Screen {
         return Minecraft.getInstance().getWindow();
     }
 }
+

--- a/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
@@ -30,7 +30,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.monster.MagmaCube;
 import net.minecraft.world.entity.monster.Slime;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Contract;
@@ -278,8 +277,6 @@ public class RemorphedMenu extends Screen {
                         // Fix slimes and magma cubes - set size to 1 (smallest)
                         if (living instanceof Slime slime) {
                             slime.setSize(1, true);
-                        } else if (living instanceof MagmaCube magmaCube) {
-                            magmaCube.setSize(1, true);
                         }
                         
                         // Disable animations for consistent rendering
@@ -307,8 +304,6 @@ public class RemorphedMenu extends Screen {
                     // Fix slimes and magma cubes - set size to 1 (smallest)
                     if (living instanceof Slime slime) {
                         slime.setSize(1, true);
-                    } else if (living instanceof MagmaCube magmaCube) {
-                        magmaCube.setSize(1, true);
                     }
                     
                     // Disable animations for consistent rendering

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/EntityWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/EntityWidget.java
@@ -16,9 +16,11 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
@@ -32,13 +34,20 @@ public class EntityWidget<T extends LivingEntity> extends ShapeWidget {
     private final T entity;
     private final int size;
     private final int id;
+    private final EntityRenderState cachedRenderState;
 
-    public EntityWidget(int id, int x, int y, int width, int height, ShapeType<T> type, @NotNull T entity, Screen parent, boolean isFavorite, boolean current, int availability) {
+    public EntityWidget(int id, int x, int y, int width, int height, ShapeType<T> type, @NotNull T entity, Screen parent, boolean isFavorite, boolean current, int availability, @Nullable EntityRenderState cachedRenderState) {
         super(x, y, width, height, parent, isFavorite, current, availability); // int x, int y, int width, int height, message
-        this.size = (int) (Remorphed.CONFIG.entity_size * (1 / (Math.max(entity.getBbHeight(), entity.getBbWidth()))));
+        // Calculate size with cap for small entities like slimes and magma cubes
+        float entitySize = Math.max(entity.getBbHeight(), entity.getBbWidth());
+        float scaleFactor = 1 / entitySize;
+        // Cap the scale factor to prevent slimes/magma cubes from being too big
+        scaleFactor = Math.min(scaleFactor, 2.0f);
+        this.size = (int) (Remorphed.CONFIG.entity_size * scaleFactor);
         this.type = type;
         this.entity = entity;
         this.id = id;
+        this.cachedRenderState = cachedRenderState; // Use cached render state with proper scale
         entity.setGlowingTag(true);
         setTooltip(Tooltip.create(ShapeType.createTooltipText(entity)));
     }
@@ -93,7 +102,7 @@ public class EntityWidget<T extends LivingEntity> extends ShapeWidget {
             int l = topPos - 25;
             int m = leftPos + 20;
             int n = topPos + 35;
-            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, entity);
+            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, entity, cachedRenderState);
         } catch (Exception e) {
             Remorphed.LOGGER.error("Error while rendering {}", ShapeType.createTooltipText(entity).getString(), e);
             setCrashed();

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/SkinWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/SkinWidget.java
@@ -2,6 +2,7 @@ package dev.tocraft.remorphed.screen.widget;
 
 import com.mojang.authlib.GameProfile;
 import dev.tocraft.remorphed.Remorphed;
+import dev.tocraft.remorphed.RemorphedClient;
 import dev.tocraft.remorphed.impl.FakeClientPlayer;
 import dev.tocraft.remorphed.network.NetworkHandler;
 import dev.tocraft.walkers.api.PlayerShape;
@@ -12,10 +13,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
@@ -24,12 +26,19 @@ public class SkinWidget extends ShapeWidget {
     private final GameProfile skin;
     private final FakeClientPlayer fakePlayer;
     private final int size;
+    private final EntityRenderState cachedRenderState;
 
-    public SkinWidget(int x, int y, int width, int height, @NotNull GameProfile skin, @NotNull FakeClientPlayer fakePlayer, Screen parent, boolean isFavorite, boolean isCurrent, int availability) {
+    public SkinWidget(int x, int y, int width, int height, @NotNull GameProfile skin, @NotNull FakeClientPlayer fakePlayer, Screen parent, boolean isFavorite, boolean isCurrent, int availability, @Nullable EntityRenderState cachedRenderState) {
         super(x, y, width, height, parent, isFavorite, isCurrent, availability);
-        this.size = (int) (Remorphed.CONFIG.entity_size * (1 / (Math.max(fakePlayer.getBbHeight(), fakePlayer.getBbWidth()))));
+        // Calculate size with cap for small entities like slimes and magma cubes
+        float entitySize = Math.max(fakePlayer.getBbHeight(), fakePlayer.getBbWidth());
+        float scaleFactor = 1 / entitySize;
+        // Cap the scale factor to prevent slimes/magma cubes from being too big
+        scaleFactor = Math.min(scaleFactor, 2.0f);
+        this.size = (int) (Remorphed.CONFIG.entity_size * scaleFactor);
         this.skin = skin;
         this.fakePlayer = fakePlayer;
+        this.cachedRenderState = cachedRenderState; // Use cached render state with proper scale
         setTooltip(Tooltip.create(Component.literal(skin.getName())));
     }
 
@@ -56,7 +65,9 @@ public class SkinWidget extends ShapeWidget {
             int l = topPos - 25;
             int m = leftPos + 20;
             int n = topPos + 35;
-            InventoryScreen.renderEntityInInventory(guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, fakePlayer);
+            // Use a unique ID for each skin widget (based on skin UUID hash)
+            int id = skin.getId().hashCode();
+            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, fakePlayer, cachedRenderState);
         }
     }
 }


### PR DESCRIPTION
*NOTE: This branch was made off of the permissions feature branch, so this PR should go in AFTER the permissions PR (#102 ). 

I noticed that every time you open the UI the entities are fully rebuilt for the list. Meaning at first you see the skins of the morphs but on the wrong skeleton basically and then over time they correct themselves. The longer your morph list the longer this takes. In the main branch this happens every time the menu is opened. In creative mode with all morphs this can take up to ~15 seconds in my experience.

This PR adds entity/render caching and a few small optimizations. Now the first time you open the menu within the game it will need to load the list properly, but after that, all the entities will stay cached until game close/server leave. This way all menu opens after first full load will be instant and the user will be able to see the correct skin AND skeleton/mesh for the mob immediately. The cache is updated as necessary on next menu open if the user has unlocked a new mob. 

In the future I think we could potentially move this caching to when the user loads into a world, so even on first menu launch the list will be perfect, but for now I think this is a great improvement for usability. 