### PR TITLE
Optimize menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ remorphed 7.1.0
 - fix broken counter in menu
 - add delete functionality to Menu - press "X" or mouse-scroll-wheel to delete
 - fix duplicate entities in menu
+- optimize menu rendering by FugLong
 
 remorphed 7.0
 ================

--- a/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
+++ b/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
@@ -9,7 +9,6 @@ import dev.tocraft.remorphed.handler.client.ClientPlayerRespawnHandler;
 import dev.tocraft.remorphed.handler.client.EntityRenderCacheHandler;
 import dev.tocraft.remorphed.mixin.client.accessor.GuiGraphicsAccessor;
 import dev.tocraft.remorphed.network.ClientNetworking;
-import dev.tocraft.remorphed.screen.RemorphedMenu;
 import dev.tocraft.remorphed.screen.render.GuiShapeRenderState;
 import dev.tocraft.remorphed.tick.KeyPressHandler;
 import net.fabricmc.api.EnvType;

--- a/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
+++ b/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
@@ -7,6 +7,7 @@ import dev.tocraft.craftedcore.registration.KeyBindingRegistry;
 import dev.tocraft.remorphed.handler.client.ClientPlayerRespawnHandler;
 import dev.tocraft.remorphed.mixin.client.accessor.GuiGraphicsAccessor;
 import dev.tocraft.remorphed.network.ClientNetworking;
+import dev.tocraft.remorphed.screen.RemorphedMenu;
 import dev.tocraft.remorphed.screen.render.GuiShapeRenderState;
 import dev.tocraft.remorphed.tick.KeyPressHandler;
 import net.fabricmc.api.EnvType;
@@ -36,6 +37,7 @@ public class RemorphedClient {
         ClientNetworking.registerPacketHandlers();
 
         ClientPlayerEvents.CLIENT_PLAYER_RESPAWN.register(new ClientPlayerRespawnHandler());
+        ClientPlayerEvents.CLIENT_PLAYER_QUIT.register(player -> RemorphedMenu.clearCache()); // clear cache on world quit
     }
 
     public static void renderEntityInInventory(

--- a/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
+++ b/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
@@ -4,7 +4,9 @@ import com.mojang.blaze3d.platform.InputConstants;
 import dev.tocraft.craftedcore.event.client.ClientPlayerEvents;
 import dev.tocraft.craftedcore.event.client.ClientTickEvents;
 import dev.tocraft.craftedcore.registration.KeyBindingRegistry;
+import dev.tocraft.remorphed.handler.client.ClientDisconnectHandler;
 import dev.tocraft.remorphed.handler.client.ClientPlayerRespawnHandler;
+import dev.tocraft.remorphed.handler.client.EntityRenderCacheHandler;
 import dev.tocraft.remorphed.mixin.client.accessor.GuiGraphicsAccessor;
 import dev.tocraft.remorphed.network.ClientNetworking;
 import dev.tocraft.remorphed.screen.RemorphedMenu;
@@ -34,10 +36,11 @@ public class RemorphedClient {
 
         // Register event handlers
         ClientTickEvents.CLIENT_PRE.register(new KeyPressHandler());
+        ClientTickEvents.CLIENT_PRE.register(new ClientDisconnectHandler());
+        ClientTickEvents.CLIENT_PRE.register(new EntityRenderCacheHandler());
         ClientNetworking.registerPacketHandlers();
 
         ClientPlayerEvents.CLIENT_PLAYER_RESPAWN.register(new ClientPlayerRespawnHandler());
-        ClientPlayerEvents.CLIENT_PLAYER_QUIT.register(player -> RemorphedMenu.clearCache()); // clear cache on world quit
     }
 
     public static void renderEntityInInventory(
@@ -51,21 +54,12 @@ public class RemorphedClient {
             Vector3f translation,
             Quaternionf rotation,
             @Nullable Quaternionf overrideCameraAngle,
-            LivingEntity entity,
-            @Nullable EntityRenderState cachedRenderState
+            LivingEntity entity
     ) {
-        EntityRenderState entityRenderState;
-        
-        if (cachedRenderState != null) {
-            // Use cached render state to avoid texture/model reloading
-            entityRenderState = cachedRenderState;
-        } else {
-            // Fallback: create new render state (shouldn't happen with proper caching)
-            EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
-            EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
-            entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
-            entityRenderState.hitboxesRenderState = null;
-        }
+        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
+        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
+        EntityRenderState entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
+        entityRenderState.hitboxesRenderState = null;
 
         GuiGraphicsAccessor accessor = ((GuiGraphicsAccessor) guiGraphics);
         accessor.getGuiRenderState().submitPicturesInPictureState(new GuiShapeRenderState(id, entityRenderState, translation, rotation, overrideCameraAngle, x1, y1, x2, y2, scale, accessor.getScissorStack().peek()));

--- a/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
+++ b/common/src/main/java/dev/tocraft/remorphed/RemorphedClient.java
@@ -49,12 +49,21 @@ public class RemorphedClient {
             Vector3f translation,
             Quaternionf rotation,
             @Nullable Quaternionf overrideCameraAngle,
-            LivingEntity entity
+            LivingEntity entity,
+            @Nullable EntityRenderState cachedRenderState
     ) {
-        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
-        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
-        EntityRenderState entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
-        entityRenderState.hitboxesRenderState = null;
+        EntityRenderState entityRenderState;
+        
+        if (cachedRenderState != null) {
+            // Use cached render state to avoid texture/model reloading
+            entityRenderState = cachedRenderState;
+        } else {
+            // Fallback: create new render state (shouldn't happen with proper caching)
+            EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
+            EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
+            entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
+            entityRenderState.hitboxesRenderState = null;
+        }
 
         GuiGraphicsAccessor accessor = ((GuiGraphicsAccessor) guiGraphics);
         accessor.getGuiRenderState().submitPicturesInPictureState(new GuiShapeRenderState(id, entityRenderState, translation, rotation, overrideCameraAngle, x1, y1, x2, y2, scale, accessor.getScissorStack().peek()));

--- a/common/src/main/java/dev/tocraft/remorphed/command/RemorphedCommand.java
+++ b/common/src/main/java/dev/tocraft/remorphed/command/RemorphedCommand.java
@@ -362,6 +362,7 @@ public class RemorphedCommand implements CommandEvents.CommandRegistration {
             rootNode.addChild(hasSkin);
         }
 
+
         dispatcher.getRoot().addChild(rootNode);
 
     }

--- a/common/src/main/java/dev/tocraft/remorphed/handler/client/ClientDisconnectHandler.java
+++ b/common/src/main/java/dev/tocraft/remorphed/handler/client/ClientDisconnectHandler.java
@@ -1,7 +1,6 @@
 package dev.tocraft.remorphed.handler.client;
 
 import dev.tocraft.craftedcore.event.client.ClientTickEvents;
-import dev.tocraft.remorphed.Remorphed;
 import dev.tocraft.remorphed.screen.EntityRenderCache;
 import net.minecraft.client.Minecraft;
 

--- a/common/src/main/java/dev/tocraft/remorphed/handler/client/ClientDisconnectHandler.java
+++ b/common/src/main/java/dev/tocraft/remorphed/handler/client/ClientDisconnectHandler.java
@@ -1,0 +1,26 @@
+package dev.tocraft.remorphed.handler.client;
+
+import dev.tocraft.craftedcore.event.client.ClientTickEvents;
+import dev.tocraft.remorphed.Remorphed;
+import dev.tocraft.remorphed.screen.EntityRenderCache;
+import net.minecraft.client.Minecraft;
+
+/**
+ * Handles clearing the entity render cache when the player disconnects from a world.
+ */
+public class ClientDisconnectHandler implements ClientTickEvents.Client {
+
+    private boolean wasInWorld = false;
+
+    @Override
+    public void tick(Minecraft client) {
+        boolean isInWorld = client.level != null && client.player != null;
+
+        // Detect transition from in-world to not-in-world (disconnect)
+        if (wasInWorld && !isInWorld) {
+            EntityRenderCache.clearCache();
+        }
+
+        wasInWorld = isInWorld;
+    }
+}

--- a/common/src/main/java/dev/tocraft/remorphed/handler/client/EntityRenderCacheHandler.java
+++ b/common/src/main/java/dev/tocraft/remorphed/handler/client/EntityRenderCacheHandler.java
@@ -1,0 +1,63 @@
+package dev.tocraft.remorphed.handler.client;
+
+import dev.tocraft.craftedcore.event.client.ClientTickEvents;
+import dev.tocraft.remorphed.Remorphed;
+import dev.tocraft.remorphed.screen.EntityRenderCache;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+
+/**
+ * Handles pre-loading entity render states when the player joins a world.
+ * This ensures the menu opens instantly without visual loading delays.
+ */
+public class EntityRenderCacheHandler implements ClientTickEvents.Client {
+
+    private boolean wasInWorld = false;
+    private boolean hasPreloaded = false;
+    private int ticksInWorld = 0;
+
+    @Override
+    public void tick(Minecraft client) {
+        boolean isInWorld = client.level != null && client.player != null;
+
+        // Detect transition from not-in-world to in-world (world join)
+        if (!wasInWorld && isInWorld) {
+            // Reset state for new world
+            hasPreloaded = false;
+            ticksInWorld = 0;
+        }
+
+        // Pre-load after being in world for a few ticks (ensures world is fully loaded)
+        if (isInWorld && !hasPreloaded) {
+            ticksInWorld++;
+
+            // Wait 20 ticks (1 second) after joining to ensure everything is loaded
+            if (ticksInWorld >= 20) {
+                hasPreloaded = true;
+                preloadForPlayer(client.player);
+            }
+        }
+
+        wasInWorld = isInWorld;
+    }
+
+    /**
+     * Pre-loads all entity and player skin render states for the given player.
+     * This runs on the main client thread.
+     *
+     * @param player The player to pre-load entities for
+     */
+    private void preloadForPlayer(LocalPlayer player) {
+        if (player == null) {
+            return;
+        }
+
+        try {
+            // Pre-load entities and player skins on main thread
+            EntityRenderCache.preloadEntities(player);
+            EntityRenderCache.preloadPlayerSkins(player);
+        } catch (Exception e) {
+            Remorphed.LOGGER.error("[Remorphed] Failed to pre-load entity render cache", e);
+        }
+    }
+}

--- a/common/src/main/java/dev/tocraft/remorphed/handler/client/EntityRenderCacheHandler.java
+++ b/common/src/main/java/dev/tocraft/remorphed/handler/client/EntityRenderCacheHandler.java
@@ -1,14 +1,23 @@
 package dev.tocraft.remorphed.handler.client;
 
+import com.mojang.authlib.GameProfile;
 import dev.tocraft.craftedcore.event.client.ClientTickEvents;
 import dev.tocraft.remorphed.Remorphed;
+import dev.tocraft.remorphed.screen.EntityPreloadScreen;
 import dev.tocraft.remorphed.screen.EntityRenderCache;
+import dev.tocraft.walkers.api.variant.ShapeType;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.Mob;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
- * Handles pre-loading entity render states when the player joins a world.
- * This ensures the menu opens instantly without visual loading delays.
+ * Handles pre-loading entity instances when the player joins a world.
+ * Entity instances are cached so subsequent menu opens are instant.
  */
 public class EntityRenderCacheHandler implements ClientTickEvents.Client {
 
@@ -42,7 +51,7 @@ public class EntityRenderCacheHandler implements ClientTickEvents.Client {
     }
 
     /**
-     * Pre-loads all entity and player skin render states for the given player.
+     * Pre-loads entity instances for the given player.
      * This runs on the main client thread.
      *
      * @param player The player to pre-load entities for
@@ -53,11 +62,50 @@ public class EntityRenderCacheHandler implements ClientTickEvents.Client {
         }
 
         try {
-            // Pre-load entities and player skins on main thread
+            // Cache entity instances
             EntityRenderCache.preloadEntities(player);
             EntityRenderCache.preloadPlayerSkins(player);
+
+            // Start background pre-rendering
+            startPreRendering(player);
         } catch (Exception e) {
-            Remorphed.LOGGER.error("[Remorphed] Failed to pre-load entity render cache", e);
+            // Silent - don't spam logs
+        }
+    }
+
+    private void startPreRendering(LocalPlayer player) {
+        List<ShapeType<?>> currentUnlockedShapes = Remorphed.getUnlockedShapes(player);
+        List<GameProfile> unlockedSkins = Remorphed.getUnlockedSkins(player);
+
+        // Apply the SAME filtering logic as RemorphedMenu lines 118-126
+        // This filters to one variant per entity type for the CURRENT mode (survival/creative)
+        List<ShapeType<?>> currentFilteredShapes = new ArrayList<>();
+        Set<net.minecraft.world.entity.EntityType<?>> seenTypes = new HashSet<>();
+        for (ShapeType<?> shapeType : currentUnlockedShapes) {
+            if (seenTypes.add(shapeType.getEntityType())) {
+                currentFilteredShapes.add(shapeType);
+            }
+        }
+
+        // Gather entities for the current filtered list (for correct ID mapping)
+        List<Mob> entitiesToRender = new ArrayList<>();
+        List<ShapeType<?>> shapesInOrder = new ArrayList<>();
+
+        for (ShapeType<?> type : currentFilteredShapes) {
+            EntityRenderCache.CachedEntityData cached = EntityRenderCache.getCachedEntity(type);
+            if (cached != null && cached.entity instanceof Mob mob) {
+                entitiesToRender.add(mob);
+                shapesInOrder.add(type);
+            }
+        }
+
+        if (!entitiesToRender.isEmpty()) {
+            // Open invisible pre-render screen with shape types for ID calculation
+            Minecraft.getInstance().setScreen(new EntityPreloadScreen(
+                entitiesToRender,
+                shapesInOrder,
+                unlockedSkins
+            ));
         }
     }
 }

--- a/common/src/main/java/dev/tocraft/remorphed/handler/client/EntityRenderCacheHandler.java
+++ b/common/src/main/java/dev/tocraft/remorphed/handler/client/EntityRenderCacheHandler.java
@@ -89,22 +89,19 @@ public class EntityRenderCacheHandler implements ClientTickEvents.Client {
 
         // Gather entities for the current filtered list (for correct ID mapping)
         List<Mob> entitiesToRender = new ArrayList<>();
-        List<ShapeType<?>> shapesInOrder = new ArrayList<>();
 
         for (ShapeType<?> type : currentFilteredShapes) {
             EntityRenderCache.CachedEntityData cached = EntityRenderCache.getCachedEntity(type);
-            if (cached != null && cached.entity instanceof Mob mob) {
+            if (cached != null && cached.entity() instanceof Mob mob) {
                 entitiesToRender.add(mob);
-                shapesInOrder.add(type);
             }
         }
 
         if (!entitiesToRender.isEmpty()) {
             // Open invisible pre-render screen with shape types for ID calculation
             Minecraft.getInstance().setScreen(new EntityPreloadScreen(
-                entitiesToRender,
-                shapesInOrder,
-                unlockedSkins
+                    entitiesToRender,
+                    unlockedSkins
             ));
         }
     }

--- a/common/src/main/java/dev/tocraft/remorphed/network/ClientPermissionCache.java
+++ b/common/src/main/java/dev/tocraft/remorphed/network/ClientPermissionCache.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Client-side cache for permission results to avoid repeated server requests
  */
+@SuppressWarnings("unused")
 @Environment(EnvType.CLIENT)
 public class ClientPermissionCache {
 

--- a/common/src/main/java/dev/tocraft/remorphed/network/PermissionCheckPacket.java
+++ b/common/src/main/java/dev/tocraft/remorphed/network/PermissionCheckPacket.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.CompoundTag;
 /**
  * Network packet for checking permissions - client-side methods only
  */
+@SuppressWarnings("unused")
 public class PermissionCheckPacket {
 
     /**

--- a/common/src/main/java/dev/tocraft/remorphed/screen/EntityPreloadScreen.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/EntityPreloadScreen.java
@@ -3,7 +3,6 @@ package dev.tocraft.remorphed.screen;
 import com.mojang.authlib.GameProfile;
 import dev.tocraft.remorphed.Remorphed;
 import dev.tocraft.remorphed.RemorphedClient;
-import dev.tocraft.walkers.api.variant.ShapeType;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
@@ -24,17 +23,15 @@ import java.util.List;
 @Environment(EnvType.CLIENT)
 public class EntityPreloadScreen extends Screen {
     private final List<Mob> entitiesToRender;
-    private final List<ShapeType<?>> shapesInOrder;
     private final List<GameProfile> skinsToRender;
     private int currentIndex = 0;
     private int finishedTicks = 0; // Ticks since finishing rendering
     private static final int ENTITIES_PER_FRAME = 10; // Render 10 entities per frame
     private static final int WAIT_AFTER_RENDER = 5; // Wait 5 ticks after rendering for textures to load
 
-    public EntityPreloadScreen(List<Mob> entities, List<ShapeType<?>> shapes, List<GameProfile> skins) {
+    public EntityPreloadScreen(List<Mob> entities, List<GameProfile> skins) {
         super(Component.literal("Preloading"));
         this.entitiesToRender = entities;
-        this.shapesInOrder = shapes;
         this.skinsToRender = skins;
     }
 
@@ -68,15 +65,15 @@ public class EntityPreloadScreen extends Screen {
                 int size = (int) (Remorphed.CONFIG.entity_size * (1 / (Math.max(entity.getBbHeight(), entity.getBbWidth()))));
 
                 RemorphedClient.renderEntityInInventory(
-                    id,  // Use calculated grid ID
-                    guiGraphics,
-                    -10000, -10000,  // Off-screen
-                    -9900, -9900,
-                    size,
-                    new Vector3f(),
-                    new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI),
-                    null,
-                    entity
+                        id,  // Use calculated grid ID
+                        guiGraphics,
+                        -10000, -10000,  // Off-screen
+                        -9900, -9900,
+                        size,
+                        new Vector3f(),
+                        new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI),
+                        null,
+                        entity
                 );
             } catch (Exception e) {
                 // Silent - entity will load on-demand if pre-render fails
@@ -90,7 +87,7 @@ public class EntityPreloadScreen extends Screen {
         if (currentIndex >= entitiesToRender.size()) {
             finishedTicks++;
             if (finishedTicks >= WAIT_AFTER_RENDER) {
-                Minecraft.getInstance().setScreen(null);
+                Minecraft.getInstance().setScreen(new RemorphedMenu());
             }
         }
     }

--- a/common/src/main/java/dev/tocraft/remorphed/screen/EntityPreloadScreen.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/EntityPreloadScreen.java
@@ -1,0 +1,107 @@
+package dev.tocraft.remorphed.screen;
+
+import com.mojang.authlib.GameProfile;
+import dev.tocraft.remorphed.Remorphed;
+import dev.tocraft.remorphed.RemorphedClient;
+import dev.tocraft.walkers.api.variant.ShapeType;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.Mob;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import java.util.List;
+
+/**
+ * Invisible screen that pre-renders entities off-screen to force texture/model loading.
+ * Renders in batches to avoid lag.
+ * Uses the same ID calculation as RemorphedMenu for GuiShapeRenderer cache compatibility.
+ */
+@Environment(EnvType.CLIENT)
+public class EntityPreloadScreen extends Screen {
+    private final List<Mob> entitiesToRender;
+    private final List<ShapeType<?>> shapesInOrder;
+    private final List<GameProfile> skinsToRender;
+    private int currentIndex = 0;
+    private int finishedTicks = 0; // Ticks since finishing rendering
+    private static final int ENTITIES_PER_FRAME = 10; // Render 10 entities per frame
+    private static final int WAIT_AFTER_RENDER = 5; // Wait 5 ticks after rendering for textures to load
+
+    public EntityPreloadScreen(List<Mob> entities, List<ShapeType<?>> shapes, List<GameProfile> skins) {
+        super(Component.literal("Preloading"));
+        this.entitiesToRender = entities;
+        this.shapesInOrder = shapes;
+        this.skinsToRender = skins;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        // Don't add any widgets - keep it completely empty
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        // Don't call super.render() - no background, no widgets, nothing visible
+
+        // Render a batch of entities far off-screen
+        int rendered = 0;
+        while (currentIndex < entitiesToRender.size() && rendered < ENTITIES_PER_FRAME) {
+            Mob entity = entitiesToRender.get(currentIndex);
+
+            // Calculate the list index (offset by skin count)
+            int listIndex = skinsToRender.size() + currentIndex;
+
+            // Calculate grid position (same as RemorphedMenu)
+            int row = listIndex / Remorphed.CONFIG.shapes_per_row;
+            int col = listIndex % Remorphed.CONFIG.shapes_per_row;
+
+            // Calculate ID using the SAME formula as RemorphedMenu
+            int id = row * Remorphed.CONFIG.shapes_per_row + col;
+
+            try {
+                // Render at reasonable size but off-screen to force texture loading
+                int size = (int) (Remorphed.CONFIG.entity_size * (1 / (Math.max(entity.getBbHeight(), entity.getBbWidth()))));
+
+                RemorphedClient.renderEntityInInventory(
+                    id,  // Use calculated grid ID
+                    guiGraphics,
+                    -10000, -10000,  // Off-screen
+                    -9900, -9900,
+                    size,
+                    new Vector3f(),
+                    new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI),
+                    null,
+                    entity
+                );
+            } catch (Exception e) {
+                // Silent - entity will load on-demand if pre-render fails
+            }
+
+            currentIndex++;
+            rendered++;
+        }
+
+        // Wait a few ticks after rendering completes to let textures fully load
+        if (currentIndex >= entitiesToRender.size()) {
+            finishedTicks++;
+            if (finishedTicks >= WAIT_AFTER_RENDER) {
+                Minecraft.getInstance().setScreen(null);
+            }
+        }
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false; // Don't pause the game
+    }
+
+    @Override
+    public void renderBackground(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        // Don't render ANY background - keep it completely transparent/invisible
+    }
+}

--- a/common/src/main/java/dev/tocraft/remorphed/screen/EntityRenderCache.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/EntityRenderCache.java
@@ -47,10 +47,10 @@ public class EntityRenderCache {
     }
 
     /**
-     * Pre-loads all unlocked entity shapes for the given player.
-     * This should be called when the player joins a world.
+     * Pre-loads ALL possible entity shapes for the given player.
+     * This caches all entities regardless of unlock status to support creative mode switching.
      *
-     * @param player The player whose unlocked shapes to cache
+     * @param player The player context
      */
     public static void preloadEntities(Player player) {
         Minecraft minecraft = Minecraft.getInstance();
@@ -58,10 +58,12 @@ public class EntityRenderCache {
             return;
         }
 
-        List<ShapeType<?>> unlockedShapes = Remorphed.getUnlockedShapes(player);
+        // Cache ALL possible shapes, not just unlocked ones
+        // This ensures entities are ready when switching to creative mode
+        List<ShapeType<?>> allShapes = ShapeType.getAllTypes(player.level());
 
-        for (ShapeType<?> type : unlockedShapes) {
-            // Skip if already cached
+        for (ShapeType<?> type : allShapes) {
+            // Skip if already cached (thread-safe check)
             if (ENTITY_CACHE.containsKey(type)) {
                 continue;
             }
@@ -75,7 +77,8 @@ public class EntityRenderCache {
                     prepareStaticEntity(mob);
 
                     // Cache the ENTITY itself (not render state!)
-                    ENTITY_CACHE.put(type, new CachedEntityData(mob));
+                    // Use putIfAbsent to avoid race conditions
+                    ENTITY_CACHE.putIfAbsent(type, new CachedEntityData(mob));
                 }
             } catch (Exception e) {
                 Remorphed.LOGGER.warn("[Remorphed] Failed to pre-load entity for type {}: {}",
@@ -104,7 +107,7 @@ public class EntityRenderCache {
                 continue;
             }
 
-            // Skip if already cached
+            // Skip if already cached (thread-safe check)
             if (PLAYER_CACHE.containsKey(profile)) {
                 continue;
             }
@@ -117,7 +120,8 @@ public class EntityRenderCache {
                 fakePlayer.setInvulnerable(true);
 
                 // Cache the ENTITY itself (not render state!)
-                PLAYER_CACHE.put(profile, new CachedEntityData(fakePlayer));
+                // Use putIfAbsent to avoid race conditions
+                PLAYER_CACHE.putIfAbsent(profile, new CachedEntityData(fakePlayer));
             } catch (Exception e) {
                 Remorphed.LOGGER.warn("[Remorphed] Failed to pre-load player skin for profile {}: {}",
                     profile.getName(), e.getMessage());
@@ -192,8 +196,8 @@ public class EntityRenderCache {
 
             if (entity instanceof Mob mob) {
                 prepareStaticEntity(mob);
-                ENTITY_CACHE.put(type, new CachedEntityData(mob));
-                Remorphed.LOGGER.debug("[Remorphed] Cached entity on-demand: {}", type.getEntityType().getDescriptionId());
+                // Use putIfAbsent to avoid race conditions
+                ENTITY_CACHE.putIfAbsent(type, new CachedEntityData(mob));
             }
         } catch (Exception e) {
             Remorphed.LOGGER.warn("[Remorphed] Failed to cache entity on-demand: {}", type.getEntityType().getDescriptionId(), e);
@@ -220,8 +224,8 @@ public class EntityRenderCache {
             FakeClientPlayer fakePlayer = new FakeClientPlayer(minecraft.level, profile);
             fakePlayer.setInvulnerable(true);
 
-            PLAYER_CACHE.put(profile, new CachedEntityData(fakePlayer));
-            Remorphed.LOGGER.debug("[Remorphed] Cached player skin on-demand: {}", profile.getName());
+            // Use putIfAbsent to avoid race conditions
+            PLAYER_CACHE.putIfAbsent(profile, new CachedEntityData(fakePlayer));
         } catch (Exception e) {
             Remorphed.LOGGER.warn("[Remorphed] Failed to cache player skin on-demand: {}", profile.getName(), e);
         }

--- a/common/src/main/java/dev/tocraft/remorphed/screen/EntityRenderCache.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/EntityRenderCache.java
@@ -22,10 +22,10 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Manages pre-loading and caching of entity render states for the Remorphed menu.
  * This prevents the visual loading delay when opening the menu for the first time.
- *
  * The cache creates isolated, static snapshots of entity render states that won't be
  * affected by real-world entities near the player.
  */
+@SuppressWarnings("unused")
 @Environment(EnvType.CLIENT)
 public class EntityRenderCache {
 
@@ -38,12 +38,7 @@ public class EntityRenderCache {
      * NOTE: We store the actual entity, NOT the EntityRenderState, because
      * EntityRenderState objects are mutable and get updated by the rendering system.
      */
-    public static class CachedEntityData {
-        public final LivingEntity entity;
-
-        public CachedEntityData(LivingEntity entity) {
-            this.entity = entity;
-        }
+    public record CachedEntityData(LivingEntity entity) {
     }
 
     /**
@@ -82,7 +77,7 @@ public class EntityRenderCache {
                 }
             } catch (Exception e) {
                 Remorphed.LOGGER.warn("[Remorphed] Failed to pre-load entity for type {}: {}",
-                    type.getEntityType().getDescriptionId(), e.getMessage());
+                        type.getEntityType().getDescriptionId(), e.getMessage());
             }
         }
     }
@@ -124,7 +119,7 @@ public class EntityRenderCache {
                 PLAYER_CACHE.putIfAbsent(profile, new CachedEntityData(fakePlayer));
             } catch (Exception e) {
                 Remorphed.LOGGER.warn("[Remorphed] Failed to pre-load player skin for profile {}: {}",
-                    profile.getName(), e.getMessage());
+                        profile.getName(), e.getMessage());
             }
         }
     }
@@ -178,7 +173,7 @@ public class EntityRenderCache {
      * Caches a single entity type on-demand.
      * Used when a player unlocks a new shape while in-world.
      *
-     * @param type The shape type to cache
+     * @param type   The shape type to cache
      * @param player The player context
      */
     public static void cacheEntity(ShapeType<?> type, Player player) {

--- a/common/src/main/java/dev/tocraft/remorphed/screen/EntityRenderCache.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/EntityRenderCache.java
@@ -1,0 +1,256 @@
+package dev.tocraft.remorphed.screen;
+
+import com.mojang.authlib.GameProfile;
+import dev.tocraft.remorphed.Remorphed;
+import dev.tocraft.remorphed.impl.FakeClientPlayer;
+import dev.tocraft.walkers.api.variant.ShapeType;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.monster.MagmaCube;
+import net.minecraft.world.entity.monster.Slime;
+import net.minecraft.world.entity.player.Player;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages pre-loading and caching of entity render states for the Remorphed menu.
+ * This prevents the visual loading delay when opening the menu for the first time.
+ *
+ * The cache creates isolated, static snapshots of entity render states that won't be
+ * affected by real-world entities near the player.
+ */
+@Environment(EnvType.CLIENT)
+public class EntityRenderCache {
+
+    // Static caches for entity and player render states
+    private static final Map<ShapeType<?>, CachedEntityData> ENTITY_CACHE = new ConcurrentHashMap<>();
+    private static final Map<GameProfile, CachedEntityData> PLAYER_CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Data container for cached entity information
+     * NOTE: We store the actual entity, NOT the EntityRenderState, because
+     * EntityRenderState objects are mutable and get updated by the rendering system.
+     */
+    public static class CachedEntityData {
+        public final LivingEntity entity;
+
+        public CachedEntityData(LivingEntity entity) {
+            this.entity = entity;
+        }
+    }
+
+    /**
+     * Pre-loads all unlocked entity shapes for the given player.
+     * This should be called when the player joins a world.
+     *
+     * @param player The player whose unlocked shapes to cache
+     */
+    public static void preloadEntities(Player player) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null) {
+            return;
+        }
+
+        List<ShapeType<?>> unlockedShapes = Remorphed.getUnlockedShapes(player);
+
+        for (ShapeType<?> type : unlockedShapes) {
+            // Skip if already cached
+            if (ENTITY_CACHE.containsKey(type)) {
+                continue;
+            }
+
+            try {
+                // Create isolated entity instance
+                Entity entity = type.create(minecraft.level, player);
+
+                if (entity instanceof Mob mob) {
+                    // Make entity completely static and isolated
+                    prepareStaticEntity(mob);
+
+                    // Cache the ENTITY itself (not render state!)
+                    ENTITY_CACHE.put(type, new CachedEntityData(mob));
+                }
+            } catch (Exception e) {
+                Remorphed.LOGGER.warn("[Remorphed] Failed to pre-load entity for type {}: {}",
+                    type.getEntityType().getDescriptionId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Pre-loads all unlocked player skins for the given player.
+     * This should be called when the player joins a world.
+     *
+     * @param player The player whose unlocked skins to cache
+     */
+    public static void preloadPlayerSkins(Player player) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null) {
+            return;
+        }
+
+        List<GameProfile> unlockedSkins = Remorphed.getUnlockedSkins(player);
+
+        for (GameProfile profile : unlockedSkins) {
+            // Skip player's own skin
+            if (profile.getId().equals(player.getUUID())) {
+                continue;
+            }
+
+            // Skip if already cached
+            if (PLAYER_CACHE.containsKey(profile)) {
+                continue;
+            }
+
+            try {
+                // Create isolated fake player instance
+                FakeClientPlayer fakePlayer = new FakeClientPlayer(minecraft.level, profile);
+
+                // Make player invulnerable (no setNoAi for player entities)
+                fakePlayer.setInvulnerable(true);
+
+                // Cache the ENTITY itself (not render state!)
+                PLAYER_CACHE.put(profile, new CachedEntityData(fakePlayer));
+            } catch (Exception e) {
+                Remorphed.LOGGER.warn("[Remorphed] Failed to pre-load player skin for profile {}: {}",
+                    profile.getName(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Prepares an entity to be completely static and isolated from world state.
+     *
+     * @param mob The mob to prepare
+     */
+    private static void prepareStaticEntity(Mob mob) {
+        // Disable AI and make invulnerable to prevent any updates
+        mob.setNoAi(true);
+        mob.setInvulnerable(true);
+
+        // Fix slimes and magma cubes - set to smallest size
+        if (mob instanceof Slime slime) {
+            slime.setSize(1, true);
+        } else if (mob instanceof MagmaCube magmaCube) {
+            magmaCube.setSize(1, true);
+        }
+
+        // Enable glowing effect for menu display
+        mob.setGlowingTag(true);
+    }
+
+    /**
+     * Gets the cached render data for an entity type.
+     * If not cached, returns null.
+     *
+     * @param type The shape type to get cached data for
+     * @return The cached data, or null if not cached
+     */
+    @Nullable
+    public static CachedEntityData getCachedEntity(ShapeType<?> type) {
+        return ENTITY_CACHE.get(type);
+    }
+
+    /**
+     * Gets the cached render data for a player skin.
+     * If not cached, returns null.
+     *
+     * @param profile The game profile to get cached data for
+     * @return The cached data, or null if not cached
+     */
+    @Nullable
+    public static CachedEntityData getCachedPlayerSkin(GameProfile profile) {
+        return PLAYER_CACHE.get(profile);
+    }
+
+    /**
+     * Caches a single entity type on-demand.
+     * Used when a player unlocks a new shape while in-world.
+     *
+     * @param type The shape type to cache
+     * @param player The player context
+     */
+    public static void cacheEntity(ShapeType<?> type, Player player) {
+        if (ENTITY_CACHE.containsKey(type)) {
+            return; // Already cached
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null) {
+            return;
+        }
+
+        try {
+            Entity entity = type.create(minecraft.level, player);
+
+            if (entity instanceof Mob mob) {
+                prepareStaticEntity(mob);
+                ENTITY_CACHE.put(type, new CachedEntityData(mob));
+                Remorphed.LOGGER.debug("[Remorphed] Cached entity on-demand: {}", type.getEntityType().getDescriptionId());
+            }
+        } catch (Exception e) {
+            Remorphed.LOGGER.warn("[Remorphed] Failed to cache entity on-demand: {}", type.getEntityType().getDescriptionId(), e);
+        }
+    }
+
+    /**
+     * Caches a single player skin on-demand.
+     * Used when a player unlocks a new skin while in-world.
+     *
+     * @param profile The game profile to cache
+     */
+    public static void cachePlayerSkin(GameProfile profile) {
+        if (PLAYER_CACHE.containsKey(profile)) {
+            return; // Already cached
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null) {
+            return;
+        }
+
+        try {
+            FakeClientPlayer fakePlayer = new FakeClientPlayer(minecraft.level, profile);
+            fakePlayer.setInvulnerable(true);
+
+            PLAYER_CACHE.put(profile, new CachedEntityData(fakePlayer));
+            Remorphed.LOGGER.debug("[Remorphed] Cached player skin on-demand: {}", profile.getName());
+        } catch (Exception e) {
+            Remorphed.LOGGER.warn("[Remorphed] Failed to cache player skin on-demand: {}", profile.getName(), e);
+        }
+    }
+
+    /**
+     * Clears all cached entities.
+     * This should be called when the player disconnects from a world.
+     */
+    public static void clearCache() {
+        ENTITY_CACHE.clear();
+        PLAYER_CACHE.clear();
+    }
+
+    /**
+     * Gets the number of cached entities.
+     *
+     * @return The cache size
+     */
+    public static int getCachedEntityCount() {
+        return ENTITY_CACHE.size();
+    }
+
+    /**
+     * Gets the number of cached player skins.
+     *
+     * @return The cache size
+     */
+    public static int getCachedPlayerSkinCount() {
+        return PLAYER_CACHE.size();
+    }
+}

--- a/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
@@ -22,12 +22,17 @@ import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
 import net.minecraft.client.gui.layouts.LinearLayout;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.monster.MagmaCube;
+import net.minecraft.world.entity.monster.Slime;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -48,6 +53,11 @@ public class RemorphedMenu extends Screen {
     private final List<GameProfile> unlockedSkins = new CopyOnWriteArrayList<>();
     private final Map<ShapeType<?>, Mob> renderEntities = new ConcurrentHashMap<>();
     private final Map<GameProfile, FakeClientPlayer> renderPlayers = new ConcurrentHashMap<>();
+
+    // Cache for EntityRenderState with proper scale - this is what prevents visual reloading
+    private static final Map<ShapeType<?>, EntityRenderState> CACHED_ENTITY_RENDER_STATES = new ConcurrentHashMap<>();
+    private static final Map<GameProfile, EntityRenderState> CACHED_PLAYER_RENDER_STATES = new ConcurrentHashMap<>();
+
 
     private final SearchWidget searchBar = createSearchBar();
     private final Button helpButton = createHelpButton();
@@ -202,6 +212,7 @@ public class RemorphedMenu extends Screen {
                         if (fakePlayer != null) {
                             boolean bl = Objects.equals(SkinShifter.getCurrentSkin(minecraft.player), skinProfile.getId()) && currentType == null;
                             if (bl) currentRow = i;
+                            EntityRenderState cachedPlayerRenderState = CACHED_PLAYER_RENDER_STATES.get(skinProfile);
                             row.add(new SkinWidget(
                                     0,
                                     0,
@@ -212,7 +223,8 @@ public class RemorphedMenu extends Screen {
                                     this,
                                     PlayerMorph.getFavoriteSkins(minecraft.player).contains(skinProfile),
                                     bl,
-                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.CONFIG.playerKillValue < 1 ? -1 : Remorphed.CONFIG.playerKillValue * PlayerMorph.getPlayerKills(minecraft.player, skinProfile.getId()) - PlayerMorph.getCounter(minecraft.player, skinProfile.getId())
+                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.CONFIG.playerKillValue < 1 ? -1 : Remorphed.CONFIG.playerKillValue * PlayerMorph.getPlayerKills(minecraft.player, skinProfile.getId()) - PlayerMorph.getCounter(minecraft.player, skinProfile.getId()),
+                                    cachedPlayerRenderState
                             ));
                         } else {
                             Remorphed.LOGGER.error("invalid skin profile: {}", skinProfile);
@@ -223,6 +235,7 @@ public class RemorphedMenu extends Screen {
                         if (entity != null) {
                             boolean bl = type.equals(currentType);
                             if (bl) currentRow = i;
+                            EntityRenderState cachedRenderState = CACHED_ENTITY_RENDER_STATES.get(type);
                             row.add(new EntityWidget<>(
                                     i * Remorphed.CONFIG.shapes_per_row + j,
                                     0,
@@ -234,7 +247,8 @@ public class RemorphedMenu extends Screen {
                                     this,
                                     PlayerMorph.getFavoriteShapes(minecraft.player).contains(type),
                                     bl,
-                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.getKillValue(type.getEntityType()) < 1 ? -1 : Remorphed.getKillValue(type.getEntityType()) * PlayerMorph.getKills(minecraft.player, type) - PlayerMorph.getCounter(minecraft.player, type)
+                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.getKillValue(type.getEntityType()) < 1 ? -1 : Remorphed.getKillValue(type.getEntityType()) * PlayerMorph.getKills(minecraft.player, type) - PlayerMorph.getCounter(minecraft.player, type),
+                                    cachedRenderState
                             ));
                         } else {
                             Remorphed.LOGGER.error("invalid shape type: {}", type.getEntityType().getDescriptionId());
@@ -256,11 +270,64 @@ public class RemorphedMenu extends Screen {
         unlockedShapes.clear();
         renderEntities.clear();
         List<ShapeType<?>> validUnlocked = Remorphed.getUnlockedShapes(player);
+
+
+
+        // Create new entities and render states only for newly unlocked shapes
         for (ShapeType<?> type : validUnlocked) {
-            Entity entity = type.create(Minecraft.getInstance().level, player);
-            if (entity instanceof Mob living) {
+            if (!CACHED_ENTITY_RENDER_STATES.containsKey(type)) {
+                try {
+                    Entity entity = type.create(Minecraft.getInstance().level, player);
+                    if (entity instanceof Mob living) {
+                        // Fix slimes and magma cubes - set size to 1 (smallest)
+                        if (living instanceof Slime slime) {
+                            slime.setSize(1, true);
+                        } else if (living instanceof MagmaCube magmaCube) {
+                            magmaCube.setSize(1, true);
+                        }
+
+                        // Disable animations for consistent rendering
+                        living.setNoAi(true);
+                        living.setInvulnerable(true);
+
+                        // Create and cache the EntityRenderState with 1.0F scale (like original)
+                        // The actual scaling is handled by the widget's size calculation
+                        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
+                        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(living);
+                        EntityRenderState entityRenderState = entityRenderer.createRenderState(living, 1.0F);
+                        entityRenderState.hitboxesRenderState = null;
+                        CACHED_ENTITY_RENDER_STATES.put(type, entityRenderState);
+
+                        // Don't cache the entity - create fresh each time to avoid state issues
+                        renderEntities.put(type, living);
+                    }
+                } catch (Exception e) {
+                    Remorphed.LOGGER.warn("Failed to create entity for type {}: {}", type.getEntityType(), e.getMessage());
+                }
+            } else {
+                // Create fresh entity but use cached render state
+                Entity entity = type.create(Minecraft.getInstance().level, player);
+                if (entity instanceof Mob living) {
+                    // Fix slimes and magma cubes - set size to 1 (smallest)
+                    if (living instanceof Slime slime) {
+                        slime.setSize(1, true);
+                    } else if (living instanceof MagmaCube magmaCube) {
+                        magmaCube.setSize(1, true);
+                    }
+
+                    // Disable animations for consistent rendering
+                    living.setNoAi(true);
+                    living.setInvulnerable(true);
+
+                    renderEntities.put(type, living);
+                }
+            }
+        }
+
+        // Add all valid unlocked shapes
+        for (ShapeType<?> type : validUnlocked) {
+            if (CACHED_ENTITY_RENDER_STATES.containsKey(type)) {
                 unlockedShapes.add(type);
-                renderEntities.put(type, living);
             }
         }
     }
@@ -269,17 +336,60 @@ public class RemorphedMenu extends Screen {
         unlockedSkins.clear();
         renderPlayers.clear();
         List<GameProfile> validUnlocked = Remorphed.getUnlockedSkins(player);
-        for (GameProfile profile : validUnlocked) {
-            if (profile.getId() != player.getUUID()) {
-                FakeClientPlayer entity = null;
-                if (minecraft != null) {
-                    entity = new FakeClientPlayer(minecraft.level, profile);
+
+        // Filter out the player's own skin
+        List<GameProfile> filteredUnlocked = validUnlocked.stream()
+            .filter(profile -> profile.getId() != player.getUUID())
+            .toList();
+
+        // Create new fake players and render states only for newly unlocked skins
+        for (GameProfile profile : filteredUnlocked) {
+            if (!CACHED_PLAYER_RENDER_STATES.containsKey(profile)) {
+                try {
+                    if (minecraft != null) {
+                        FakeClientPlayer entity = new FakeClientPlayer(minecraft.level, profile);
+
+                        // Create and cache the EntityRenderState with 1.0F scale (like original)
+                        // The actual scaling is handled by the widget's size calculation
+                        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
+                        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
+                        EntityRenderState entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
+                        entityRenderState.hitboxesRenderState = null;
+                        CACHED_PLAYER_RENDER_STATES.put(profile, entityRenderState);
+
+                        // Don't cache the player - create fresh each time to avoid state issues
+                        renderPlayers.put(profile, entity);
+                    }
+                } catch (Exception e) {
+                    Remorphed.LOGGER.warn("Failed to create fake player for profile {}: {}", profile.getName(), e.getMessage());
                 }
+            } else {
+                // Create fresh player but use cached render state
+                if (minecraft != null) {
+                    FakeClientPlayer entity = new FakeClientPlayer(minecraft.level, profile);
+                    renderPlayers.put(profile, entity);
+                }
+            }
+        }
+
+        // Add all valid unlocked skins
+        for (GameProfile profile : filteredUnlocked) {
+            if (CACHED_PLAYER_RENDER_STATES.containsKey(profile)) {
                 unlockedSkins.add(profile);
-                renderPlayers.put(profile, entity);
             }
         }
     }
+
+    /**
+     * Clears the entity and player caches. Call this when the player logs out
+     * or when you want to force a complete refresh of all entities.
+     */
+    public static void clearCache() {
+        CACHED_ENTITY_RENDER_STATES.clear();
+        CACHED_PLAYER_RENDER_STATES.clear();
+        Remorphed.LOGGER.info("Cleared render state caches");
+    }
+
 
     protected void addFooter() {
         this.layout.addToFooter(Button.builder(CommonComponents.GUI_DONE, (button) -> this.onClose()).width(200).build());

--- a/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
@@ -31,7 +31,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.monster.MagmaCube;
 import net.minecraft.world.entity.monster.Slime;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Contract;
@@ -282,8 +281,6 @@ public class RemorphedMenu extends Screen {
                         // Fix slimes and magma cubes - set size to 1 (smallest)
                         if (living instanceof Slime slime) {
                             slime.setSize(1, true);
-                        } else if (living instanceof MagmaCube magmaCube) {
-                            magmaCube.setSize(1, true);
                         }
 
                         // Disable animations for consistent rendering
@@ -311,8 +308,6 @@ public class RemorphedMenu extends Screen {
                     // Fix slimes and magma cubes - set size to 1 (smallest)
                     if (living instanceof Slime slime) {
                         slime.setSize(1, true);
-                    } else if (living instanceof MagmaCube magmaCube) {
-                        magmaCube.setSize(1, true);
                     }
 
                     // Disable animations for consistent rendering

--- a/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
@@ -7,6 +7,7 @@ import dev.tocraft.remorphed.impl.FakeClientPlayer;
 import dev.tocraft.remorphed.impl.PlayerMorph;
 import dev.tocraft.remorphed.mixin.client.accessor.ScreenAccessor;
 import dev.tocraft.remorphed.screen.widget.*;
+import dev.tocraft.remorphed.screen.EntityRenderCache;
 import dev.tocraft.skinshifter.SkinShifter;
 import dev.tocraft.walkers.Walkers;
 import dev.tocraft.walkers.api.PlayerShape;
@@ -22,9 +23,6 @@ import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
 import net.minecraft.client.gui.layouts.LinearLayout;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.player.AbstractClientPlayer;
-import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
-import net.minecraft.client.renderer.entity.EntityRenderer;
-import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
@@ -52,10 +50,6 @@ public class RemorphedMenu extends Screen {
     private final List<GameProfile> unlockedSkins = new CopyOnWriteArrayList<>();
     private final Map<ShapeType<?>, Mob> renderEntities = new ConcurrentHashMap<>();
     private final Map<GameProfile, FakeClientPlayer> renderPlayers = new ConcurrentHashMap<>();
-
-    // Cache for EntityRenderState with proper scale - this is what prevents visual reloading
-    private static final Map<ShapeType<?>, EntityRenderState> CACHED_ENTITY_RENDER_STATES = new ConcurrentHashMap<>();
-    private static final Map<GameProfile, EntityRenderState> CACHED_PLAYER_RENDER_STATES = new ConcurrentHashMap<>();
 
 
     private final SearchWidget searchBar = createSearchBar();
@@ -211,19 +205,17 @@ public class RemorphedMenu extends Screen {
                         if (fakePlayer != null) {
                             boolean bl = Objects.equals(SkinShifter.getCurrentSkin(minecraft.player), skinProfile.getId()) && currentType == null;
                             if (bl) currentRow = i;
-                            EntityRenderState cachedPlayerRenderState = CACHED_PLAYER_RENDER_STATES.get(skinProfile);
                             row.add(new SkinWidget(
                                     0,
                                     0,
                                     0,
                                     0,
                                     skinProfile,
-                                    new FakeClientPlayer(minecraft.level, skinProfile),
+                                    (FakeClientPlayer) fakePlayer,
                                     this,
                                     PlayerMorph.getFavoriteSkins(minecraft.player).contains(skinProfile),
                                     bl,
-                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.CONFIG.playerKillValue < 1 ? -1 : Remorphed.CONFIG.playerKillValue * PlayerMorph.getPlayerKills(minecraft.player, skinProfile.getId()) - PlayerMorph.getCounter(minecraft.player, skinProfile.getId()),
-                                    cachedPlayerRenderState
+                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.CONFIG.playerKillValue < 1 ? -1 : Remorphed.CONFIG.playerKillValue * PlayerMorph.getPlayerKills(minecraft.player, skinProfile.getId()) - PlayerMorph.getCounter(minecraft.player, skinProfile.getId())
                             ));
                         } else {
                             Remorphed.LOGGER.error("invalid skin profile: {}", skinProfile);
@@ -234,7 +226,6 @@ public class RemorphedMenu extends Screen {
                         if (entity != null) {
                             boolean bl = type.equals(currentType);
                             if (bl) currentRow = i;
-                            EntityRenderState cachedRenderState = CACHED_ENTITY_RENDER_STATES.get(type);
                             row.add(new EntityWidget<>(
                                     i * Remorphed.CONFIG.shapes_per_row + j,
                                     0,
@@ -246,8 +237,7 @@ public class RemorphedMenu extends Screen {
                                     this,
                                     PlayerMorph.getFavoriteShapes(minecraft.player).contains(type),
                                     bl,
-                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.getKillValue(type.getEntityType()) < 1 ? -1 : Remorphed.getKillValue(type.getEntityType()) * PlayerMorph.getKills(minecraft.player, type) - PlayerMorph.getCounter(minecraft.player, type),
-                                    cachedRenderState
+                                    Remorphed.canUseEveryShape(minecraft.player) || Remorphed.getKillValue(type.getEntityType()) < 1 ? -1 : Remorphed.getKillValue(type.getEntityType()) * PlayerMorph.getKills(minecraft.player, type) - PlayerMorph.getCounter(minecraft.player, type)
                             ));
                         } else {
                             Remorphed.LOGGER.error("invalid shape type: {}", type.getEntityType().getDescriptionId());
@@ -268,61 +258,27 @@ public class RemorphedMenu extends Screen {
     public synchronized void populateUnlockedRenderEntities(Player player) {
         unlockedShapes.clear();
         renderEntities.clear();
+
         List<ShapeType<?>> validUnlocked = Remorphed.getUnlockedShapes(player);
 
-
-
-        // Create new entities and render states only for newly unlocked shapes
         for (ShapeType<?> type : validUnlocked) {
-            if (!CACHED_ENTITY_RENDER_STATES.containsKey(type)) {
-                try {
-                    Entity entity = type.create(Minecraft.getInstance().level, player);
-                    if (entity instanceof Mob living) {
-                        // Fix slimes and magma cubes - set size to 1 (smallest)
-                        if (living instanceof Slime slime) {
-                            slime.setSize(1, true);
-                        }
+            // Try to get from global cache first
+            EntityRenderCache.CachedEntityData cachedData = EntityRenderCache.getCachedEntity(type);
 
-                        // Disable animations for consistent rendering
-                        living.setNoAi(true);
-                        living.setInvulnerable(true);
-
-                        // Create and cache the EntityRenderState with 1.0F scale (like original)
-                        // The actual scaling is handled by the widget's size calculation
-                        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
-                        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(living);
-                        EntityRenderState entityRenderState = entityRenderer.createRenderState(living, 1.0F);
-                        entityRenderState.hitboxesRenderState = null;
-                        CACHED_ENTITY_RENDER_STATES.put(type, entityRenderState);
-
-                        // Don't cache the entity - create fresh each time to avoid state issues
-                        renderEntities.put(type, living);
-                    }
-                } catch (Exception e) {
-                    Remorphed.LOGGER.warn("Failed to create entity for type {}: {}", type.getEntityType(), e.getMessage());
-                }
-            } else {
-                // Create fresh entity but use cached render state
-                Entity entity = type.create(Minecraft.getInstance().level, player);
-                if (entity instanceof Mob living) {
-                    // Fix slimes and magma cubes - set size to 1 (smallest)
-                    if (living instanceof Slime slime) {
-                        slime.setSize(1, true);
-                    }
-
-                    // Disable animations for consistent rendering
-                    living.setNoAi(true);
-                    living.setInvulnerable(true);
-
-                    renderEntities.put(type, living);
-                }
-            }
-        }
-
-        // Add all valid unlocked shapes
-        for (ShapeType<?> type : validUnlocked) {
-            if (CACHED_ENTITY_RENDER_STATES.containsKey(type)) {
+            if (cachedData != null && cachedData.entity instanceof Mob cachedMob) {
+                // Cache hit! Use the pre-loaded entity
+                renderEntities.put(type, cachedMob);
                 unlockedShapes.add(type);
+            } else {
+                // Cache miss - create, prepare, and cache entity on-demand
+                EntityRenderCache.cacheEntity(type, player);
+
+                // Now retrieve the prepared entity from cache
+                cachedData = EntityRenderCache.getCachedEntity(type);
+                if (cachedData != null && cachedData.entity instanceof Mob cachedMob) {
+                    renderEntities.put(type, cachedMob);
+                    unlockedShapes.add(type);
+                }
             }
         }
     }
@@ -330,47 +286,29 @@ public class RemorphedMenu extends Screen {
     public synchronized void populateUnlockedRenderPlayers(Player player) {
         unlockedSkins.clear();
         renderPlayers.clear();
+
         List<GameProfile> validUnlocked = Remorphed.getUnlockedSkins(player);
 
-        // Filter out the player's own skin
-        List<GameProfile> filteredUnlocked = validUnlocked.stream()
-            .filter(profile -> profile.getId() != player.getUUID())
-            .toList();
+        for (GameProfile profile : validUnlocked) {
+            if (profile.getId() != player.getUUID()) {
+                // Try to get from global cache first
+                EntityRenderCache.CachedEntityData cachedData = EntityRenderCache.getCachedPlayerSkin(profile);
 
-        // Create new fake players and render states only for newly unlocked skins
-        for (GameProfile profile : filteredUnlocked) {
-            if (!CACHED_PLAYER_RENDER_STATES.containsKey(profile)) {
-                try {
-                    if (minecraft != null) {
-                        FakeClientPlayer entity = new FakeClientPlayer(minecraft.level, profile);
+                if (cachedData != null && cachedData.entity instanceof FakeClientPlayer cachedPlayer) {
+                    // Cache hit! Use the pre-loaded player
+                    renderPlayers.put(profile, cachedPlayer);
+                    unlockedSkins.add(profile);
+                } else {
+                    // Cache miss - create, prepare, and cache player on-demand
+                    EntityRenderCache.cachePlayerSkin(profile);
 
-                        // Create and cache the EntityRenderState with 1.0F scale (like original)
-                        // The actual scaling is handled by the widget's size calculation
-                        EntityRenderDispatcher entityRenderDispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
-                        EntityRenderer<? super LivingEntity, ?> entityRenderer = entityRenderDispatcher.getRenderer(entity);
-                        EntityRenderState entityRenderState = entityRenderer.createRenderState(entity, 1.0F);
-                        entityRenderState.hitboxesRenderState = null;
-                        CACHED_PLAYER_RENDER_STATES.put(profile, entityRenderState);
-
-                        // Don't cache the player - create fresh each time to avoid state issues
-                        renderPlayers.put(profile, entity);
+                    // Now retrieve the prepared player from cache
+                    cachedData = EntityRenderCache.getCachedPlayerSkin(profile);
+                    if (cachedData != null && cachedData.entity instanceof FakeClientPlayer cachedPlayer) {
+                        renderPlayers.put(profile, cachedPlayer);
+                        unlockedSkins.add(profile);
                     }
-                } catch (Exception e) {
-                    Remorphed.LOGGER.warn("Failed to create fake player for profile {}: {}", profile.getName(), e.getMessage());
                 }
-            } else {
-                // Create fresh player but use cached render state
-                if (minecraft != null) {
-                    FakeClientPlayer entity = new FakeClientPlayer(minecraft.level, profile);
-                    renderPlayers.put(profile, entity);
-                }
-            }
-        }
-
-        // Add all valid unlocked skins
-        for (GameProfile profile : filteredUnlocked) {
-            if (CACHED_PLAYER_RENDER_STATES.containsKey(profile)) {
-                unlockedSkins.add(profile);
             }
         }
     }
@@ -380,9 +318,7 @@ public class RemorphedMenu extends Screen {
      * or when you want to force a complete refresh of all entities.
      */
     public static void clearCache() {
-        CACHED_ENTITY_RENDER_STATES.clear();
-        CACHED_PLAYER_RENDER_STATES.clear();
-        Remorphed.LOGGER.info("Cleared render state caches");
+        EntityRenderCache.clearCache();
     }
 
 

--- a/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
@@ -7,7 +7,6 @@ import dev.tocraft.remorphed.impl.FakeClientPlayer;
 import dev.tocraft.remorphed.impl.PlayerMorph;
 import dev.tocraft.remorphed.mixin.client.accessor.ScreenAccessor;
 import dev.tocraft.remorphed.screen.widget.*;
-import dev.tocraft.remorphed.screen.EntityRenderCache;
 import dev.tocraft.skinshifter.SkinShifter;
 import dev.tocraft.walkers.Walkers;
 import dev.tocraft.walkers.api.PlayerShape;
@@ -25,11 +24,9 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.monster.Slime;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -266,7 +263,7 @@ public class RemorphedMenu extends Screen {
             // Try to get from global cache first
             EntityRenderCache.CachedEntityData cachedData = EntityRenderCache.getCachedEntity(type);
 
-            if (cachedData != null && cachedData.entity instanceof Mob cachedMob) {
+            if (cachedData != null && cachedData.entity() instanceof Mob cachedMob) {
                 // Cache hit! Use the pre-loaded entity
                 renderEntities.put(type, cachedMob);
                 unlockedShapes.add(type);
@@ -276,7 +273,7 @@ public class RemorphedMenu extends Screen {
 
                 // Now retrieve the prepared entity from cache
                 cachedData = EntityRenderCache.getCachedEntity(type);
-                if (cachedData != null && cachedData.entity instanceof Mob cachedMob) {
+                if (cachedData != null && cachedData.entity() instanceof Mob cachedMob) {
                     renderEntities.put(type, cachedMob);
                     unlockedShapes.add(type);
                 }
@@ -295,7 +292,7 @@ public class RemorphedMenu extends Screen {
                 // Try to get from global cache first
                 EntityRenderCache.CachedEntityData cachedData = EntityRenderCache.getCachedPlayerSkin(profile);
 
-                if (cachedData != null && cachedData.entity instanceof FakeClientPlayer cachedPlayer) {
+                if (cachedData != null && cachedData.entity() instanceof FakeClientPlayer cachedPlayer) {
                     // Cache hit! Use the pre-loaded player
                     renderPlayers.put(profile, cachedPlayer);
                     unlockedSkins.add(profile);
@@ -305,7 +302,7 @@ public class RemorphedMenu extends Screen {
 
                     // Now retrieve the prepared player from cache
                     cachedData = EntityRenderCache.getCachedPlayerSkin(profile);
-                    if (cachedData != null && cachedData.entity instanceof FakeClientPlayer cachedPlayer) {
+                    if (cachedData != null && cachedData.entity() instanceof FakeClientPlayer cachedPlayer) {
                         renderPlayers.put(profile, cachedPlayer);
                         unlockedSkins.add(profile);
                     }

--- a/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/RemorphedMenu.java
@@ -117,10 +117,12 @@ public class RemorphedMenu extends Screen {
 
             // filter unlocked
             List<ShapeType<?>> newUnlocked = new ArrayList<>();
+            Set<EntityType<?>> seenTypes = new HashSet<>();
             for (ShapeType<?> shapeType : unlockedShapes) {
-                if (!newUnlocked.stream().map(ShapeType::getEntityType).toList().contains(shapeType.getEntityType())) {
+                if (!seenTypes.contains(shapeType.getEntityType())) {
                     if (currentShape == null || shapeType.equals(currentShape) || shapeType.getEntityType() != currentShape.getEntityType() || shapeType.getVariantData() == currentShape.getVariantData()) { // only add the current variant, NOT the default one (additionally)
                         newUnlocked.add(shapeType);
+                        seenTypes.add(shapeType.getEntityType());
                     }
                 }
             }
@@ -168,7 +170,6 @@ public class RemorphedMenu extends Screen {
                     .toList();
 
             populateShapeWidgets(filteredShapes, filteredSkins);
-            Remorphed.LOGGER.info("Loaded {} entities and {} skins for rendering", filteredShapes.size(), filteredSkins.size());
 
             lastSearchContents = text;
         });

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/EntityWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/EntityWidget.java
@@ -19,7 +19,6 @@ import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/EntityWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/EntityWidget.java
@@ -16,9 +16,11 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
@@ -32,13 +34,20 @@ public class EntityWidget<T extends LivingEntity> extends ShapeWidget {
     private final T entity;
     private final int size;
     private final int id;
+    private final EntityRenderState cachedRenderState;
 
-    public EntityWidget(int id, int x, int y, int width, int height, ShapeType<T> type, @NotNull T entity, Screen parent, boolean isFavorite, boolean current, int availability) {
+    public EntityWidget(int id, int x, int y, int width, int height, ShapeType<T> type, @NotNull T entity, Screen parent, boolean isFavorite, boolean current, int availability, @Nullable EntityRenderState cachedRenderState) {
         super(x, y, width, height, parent, isFavorite, current, availability); // int x, int y, int width, int height, message
-        this.size = (int) (Remorphed.CONFIG.entity_size * (1 / (Math.max(entity.getBbHeight(), entity.getBbWidth()))));
+        // Calculate size with cap for small entities like slimes and magma cubes
+        float entitySize = Math.max(entity.getBbHeight(), entity.getBbWidth());
+        float scaleFactor = 1 / entitySize;
+        // Cap the scale factor to prevent slimes/magma cubes from being too big
+        scaleFactor = Math.min(scaleFactor, 2.0f);
+        this.size = (int) (Remorphed.CONFIG.entity_size * scaleFactor);
         this.type = type;
         this.entity = entity;
         this.id = id;
+        this.cachedRenderState = cachedRenderState; // Use cached render state with proper scale
         entity.setGlowingTag(true);
         setTooltip(Tooltip.create(ShapeType.createTooltipText(entity)));
     }
@@ -93,7 +102,7 @@ public class EntityWidget<T extends LivingEntity> extends ShapeWidget {
             int l = topPos - 25;
             int m = leftPos + 20;
             int n = topPos + 35;
-            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, entity);
+            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, entity, cachedRenderState);
         } catch (Exception e) {
             Remorphed.LOGGER.error("Error while rendering {}", ShapeType.createTooltipText(entity).getString(), e);
             setCrashed();

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/EntityWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/EntityWidget.java
@@ -16,7 +16,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
-import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
@@ -34,20 +33,13 @@ public class EntityWidget<T extends LivingEntity> extends ShapeWidget {
     private final T entity;
     private final int size;
     private final int id;
-    private final EntityRenderState cachedRenderState;
 
-    public EntityWidget(int id, int x, int y, int width, int height, ShapeType<T> type, @NotNull T entity, Screen parent, boolean isFavorite, boolean current, int availability, @Nullable EntityRenderState cachedRenderState) {
-        super(x, y, width, height, parent, isFavorite, current, availability); // int x, int y, int width, int height, message
-        // Calculate size with cap for small entities like slimes and magma cubes
-        float entitySize = Math.max(entity.getBbHeight(), entity.getBbWidth());
-        float scaleFactor = 1 / entitySize;
-        // Cap the scale factor to prevent slimes/magma cubes from being too big
-        scaleFactor = Math.min(scaleFactor, 2.0f);
-        this.size = (int) (Remorphed.CONFIG.entity_size * scaleFactor);
+    public EntityWidget(int id, int x, int y, int width, int height, ShapeType<T> type, @NotNull T entity, Screen parent, boolean isFavorite, boolean current, int availability) {
+        super(x, y, width, height, parent, isFavorite, current, availability);
+        this.size = (int) (Remorphed.CONFIG.entity_size * (1 / (Math.max(entity.getBbHeight(), entity.getBbWidth()))));
         this.type = type;
         this.entity = entity;
         this.id = id;
-        this.cachedRenderState = cachedRenderState; // Use cached render state with proper scale
         entity.setGlowingTag(true);
         setTooltip(Tooltip.create(ShapeType.createTooltipText(entity)));
     }
@@ -95,14 +87,15 @@ public class EntityWidget<T extends LivingEntity> extends ShapeWidget {
         // Some entities (namely Aether mobs) crash when rendered in a GUI.
         // Unsure as to the cause, but this try/catch should prevent the game from entirely dipping out.
         try {
-            // ARGH
             int leftPos = (int) (getX() + (float) this.getWidth() / 2);
             int topPos = (int) (getY() + this.getHeight() * .75f);
             int k = leftPos - 20;
             int l = topPos - 25;
             int m = leftPos + 20;
             int n = topPos + 35;
-            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, entity, cachedRenderState);
+            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, (float) size,
+                    new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI),
+                    null, entity);
         } catch (Exception e) {
             Remorphed.LOGGER.error("Error while rendering {}", ShapeType.createTooltipText(entity).getString(), e);
             setCrashed();

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/ShapeWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/ShapeWidget.java
@@ -78,8 +78,7 @@ public abstract class ShapeWidget extends AbstractButton {
                 String s = String.valueOf(availability);
                 int w = parent.getFont().width(s);
                 guiGraphics.drawString(parent.getFont(), s, getX() + getWidth() - w - getWidth() / 8, (int) (getY() + getHeight() * 0.125), -1, false);
-            }
-            else if (availability == 0) {
+            } else if (availability == 0) {
                 guiGraphics.blit(RenderPipelines.GUI_TEXTURED, Remorphed.id("textures/gui/deleted.png"), getX(), getY(), 0, 0, getWidth(), getHeight(), 48, 32, 48, 32);
             }
 

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/SkinWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/SkinWidget.java
@@ -13,7 +13,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
@@ -26,19 +25,12 @@ public class SkinWidget extends ShapeWidget {
     private final GameProfile skin;
     private final FakeClientPlayer fakePlayer;
     private final int size;
-    private final EntityRenderState cachedRenderState;
 
-    public SkinWidget(int x, int y, int width, int height, @NotNull GameProfile skin, @NotNull FakeClientPlayer fakePlayer, Screen parent, boolean isFavorite, boolean isCurrent, int availability, @Nullable EntityRenderState cachedRenderState) {
+    public SkinWidget(int x, int y, int width, int height, @NotNull GameProfile skin, @NotNull FakeClientPlayer fakePlayer, Screen parent, boolean isFavorite, boolean isCurrent, int availability) {
         super(x, y, width, height, parent, isFavorite, isCurrent, availability);
-        // Calculate size with cap for small entities like slimes and magma cubes
-        float entitySize = Math.max(fakePlayer.getBbHeight(), fakePlayer.getBbWidth());
-        float scaleFactor = 1 / entitySize;
-        // Cap the scale factor to prevent slimes/magma cubes from being too big
-        scaleFactor = Math.min(scaleFactor, 2.0f);
-        this.size = (int) (Remorphed.CONFIG.entity_size * scaleFactor);
+        this.size = (int) (Remorphed.CONFIG.entity_size * (1 / (Math.max(fakePlayer.getBbHeight(), fakePlayer.getBbWidth()))));
         this.skin = skin;
         this.fakePlayer = fakePlayer;
-        this.cachedRenderState = cachedRenderState; // Use cached render state with proper scale
         setTooltip(Tooltip.create(Component.literal(skin.getName())));
     }
 
@@ -67,7 +59,9 @@ public class SkinWidget extends ShapeWidget {
             int n = topPos + 35;
             // Use a unique ID for each skin widget (based on skin UUID hash)
             int id = skin.getId().hashCode();
-            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, fakePlayer, cachedRenderState);
+            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, (float) size,
+                    new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI),
+                    null, fakePlayer);
         }
     }
 

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/SkinWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/SkinWidget.java
@@ -2,6 +2,7 @@ package dev.tocraft.remorphed.screen.widget;
 
 import com.mojang.authlib.GameProfile;
 import dev.tocraft.remorphed.Remorphed;
+import dev.tocraft.remorphed.RemorphedClient;
 import dev.tocraft.remorphed.impl.FakeClientPlayer;
 import dev.tocraft.remorphed.network.NetworkHandler;
 import dev.tocraft.walkers.api.PlayerShape;
@@ -12,10 +13,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
@@ -24,12 +26,19 @@ public class SkinWidget extends ShapeWidget {
     private final GameProfile skin;
     private final FakeClientPlayer fakePlayer;
     private final int size;
+    private final EntityRenderState cachedRenderState;
 
-    public SkinWidget(int x, int y, int width, int height, @NotNull GameProfile skin, @NotNull FakeClientPlayer fakePlayer, Screen parent, boolean isFavorite, boolean isCurrent, int availability) {
+    public SkinWidget(int x, int y, int width, int height, @NotNull GameProfile skin, @NotNull FakeClientPlayer fakePlayer, Screen parent, boolean isFavorite, boolean isCurrent, int availability, @Nullable EntityRenderState cachedRenderState) {
         super(x, y, width, height, parent, isFavorite, isCurrent, availability);
-        this.size = (int) (Remorphed.CONFIG.entity_size * (1 / (Math.max(fakePlayer.getBbHeight(), fakePlayer.getBbWidth()))));
+        // Calculate size with cap for small entities like slimes and magma cubes
+        float entitySize = Math.max(fakePlayer.getBbHeight(), fakePlayer.getBbWidth());
+        float scaleFactor = 1 / entitySize;
+        // Cap the scale factor to prevent slimes/magma cubes from being too big
+        scaleFactor = Math.min(scaleFactor, 2.0f);
+        this.size = (int) (Remorphed.CONFIG.entity_size * scaleFactor);
         this.skin = skin;
         this.fakePlayer = fakePlayer;
+        this.cachedRenderState = cachedRenderState; // Use cached render state with proper scale
         setTooltip(Tooltip.create(Component.literal(skin.getName())));
     }
 
@@ -56,7 +65,9 @@ public class SkinWidget extends ShapeWidget {
             int l = topPos - 25;
             int m = leftPos + 20;
             int n = topPos + 35;
-            InventoryScreen.renderEntityInInventory(guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, fakePlayer);
+            // Use a unique ID for each skin widget (based on skin UUID hash)
+            int id = skin.getId().hashCode();
+            RemorphedClient.renderEntityInInventory(id, guiGraphics, k, l, m, n, size, new Vector3f(), new Quaternionf().rotationXYZ(0.43633232F, (float) Math.PI, (float) Math.PI), null, fakePlayer, cachedRenderState);
         }
     }
 

--- a/common/src/main/java/dev/tocraft/remorphed/screen/widget/SkinWidget.java
+++ b/common/src/main/java/dev/tocraft/remorphed/screen/widget/SkinWidget.java
@@ -16,7 +16,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 


### PR DESCRIPTION
This contains all menu optimizations by @FugLong. However, since there is still one error (cited below), the changes are still part of this PR. I hope to implement it as soon as possible.

> I can't seem to isolate the entities in the menu so they are static. Anytime the user goes into 3rd person while morphed, or goes near a mob in their list in the world, the real entity takes over the menu entry and shows the mobs anims, rotation, etc. So there are still ways to get menu entries where the mob is facing the wrong way. This doesn't have to do with this branch so we can ignore it I think, but I hope to figure out a solution for this as well at some point.